### PR TITLE
Update nbkit.py

### DIFF
--- a/fastpm/nbkit.py
+++ b/fastpm/nbkit.py
@@ -40,7 +40,7 @@ class FastPMCatalogSource(CatalogSource):
         self.RSD = 1.0 / (H0 * aend * self.cosmo.efunc(1.0 / aend - 1))
 
         self._size = len(Q)
-        CatalogSource.__init__(self, comm=linear.comm, use_cache=False)
+        CatalogSource.__init__(self, comm=linear.comm)
 
         self._csize = self.comm.allreduce(self._size)
 


### PR DESCRIPTION
Removed offending "use_cache=False" causing problems when calling FastPMCatalogSource from nbodykit